### PR TITLE
Somewhat working pcap output

### DIFF
--- a/rawsniff/Makefile
+++ b/rawsniff/Makefile
@@ -1,8 +1,10 @@
 LIBUSB = libusb-1.0
+LIBPCAP = libpcap
 
-CFLAGS = -W -Wall -O
-CFLAGS += $(shell pkg-config $(LIBUSB) --cflags)
-LDFLAGS = $(shell pkg-config $(LIBUSB) --libs)
+CFLAGS = -W -Wall -O -g
+CFLAGS += $(shell pkg-config $(LIBUSB) --cflags) $(shell pkg-config $(LIBPCAP) --cflags)
+LDFLAGS = $(shell pkg-config $(LIBUSB) --libs)  $(shell pkg-config $(LIBPCAP) --libs) 
+
 
 all: rawsniff
 


### PR DESCRIPTION
I got a CC2540 dongle (different manufacturer) and got the code running on MacOS.

* One needs to claim an interface first, otherwise one gets error messages for bulk transfers.

Verified with USB sniffer on Windows: the USB dongle at hand has the same protocol.

Additionally I replaced the console dump by pcap file output, suitable to be read by wireshark.

Motivated by https://github.com/christianpanton/ccsniffer/blob/master/ccsniffer.py verified the payload: It is BLE link layer protocol.

Used it to sniff advertisement packets of several devices.

Thanks for your great starting point